### PR TITLE
Solucionado el problema con el numero de cuenta en user.php

### DIFF
--- a/Process_credit.php
+++ b/Process_credit.php
@@ -14,7 +14,7 @@ while ($row = mysqli_fetch_row($result)){
 ?>
 <?php   
         $id_U = $row[0]; //guardamos su id en una variable
-        $balance = $row[9];
+        $balance = $row[11];
 ?><br><br>
 <?php
 }
@@ -39,6 +39,7 @@ $consult_U = mysqli_fetch_array($consult_U);
             $sql2 = "UPDATE users
                     SET    balance = '$NewBalance'
                     WHERE  id_U  = '$id_U'";    
+
             }else {
             echo "<script>
             alert('error');


### PR DESCRIPTION
solucione el error en el que el numero de cuenta del administrador salia en la cantidad del dinero del usuario, el error era causado por un error con una row que estaba mandando a llamar una variable que no era la que ocupaba